### PR TITLE
Add missing field to yarc_resource_t struct terminator.

### DIFF
--- a/app/yarc.c
+++ b/app/yarc.c
@@ -889,7 +889,7 @@ int main(int argc, char** argv)
 				file->basename, file->identifier, file->identifier, (int) file->offset);
 		}
 
-		fprintf(out->fp, "  { \"\", 0, 0 }\n};\n");
+		fprintf(out->fp, "  { \"\", 0, 0, 0 }\n};\n");
 		fprintf(out->fp, "\n");
 
 		fprintf(out->fp, "%s%s_bundle_t %s_%s_bundle = {\n",


### PR DESCRIPTION
The yarc_resource_t struct has four fields.